### PR TITLE
Add bus factor analyses

### DIFF
--- a/notebooks/bus-factor.ipynb
+++ b/notebooks/bus-factor.ipynb
@@ -1,0 +1,9176 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bus Factor: How high is the risk to a project should the most active people leave?\n",
+    "\n",
+    "Bus factor quantifies the amount of contributors a project can afford to lose before it stalls by hypothetically having these people get run over a bus. Typically, it is the smallest number of people that make up 50% of contributions. \n",
+    "\n",
+    "In this notebook, we analyze bus factor according to a user-inputted percent of contributions with the option to parameterize by a time window and step size. We explore contributors including but not limited to individuals **1) making commits, 2) creating issues, and 3) creating, reviewing, and engaging in conversation around PRs**.\n",
+    "\n",
+    "**Note:** In the notebook, we use the Ansible repository as an example but our analyses can be replicated with any GitHub repository."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Table of Contents\n",
+    "- [1. Connect to Augur database](#connect-to-augur-database)\n",
+    "- [2. Query data](#query-data)\n",
+    "- [3. Calculate bus factor](#calculate-bus-factor)\n",
+    "- [4. Bus factor by number of commits](#bus-factor-by-number-of-commits)\n",
+    "- [5. Bus factor by number of issues](#bus-factor-by-number-of-issues)\n",
+    "- [6. Bus factor by number of PRs](#bus-factor-by-number-of-prs)\n",
+    "- [7. Conclusion](#conclusion)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q sqlalchemy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import the required libraries and packages\n",
+    "import sqlalchemy as salc\n",
+    "import json\n",
+    "import os\n",
+    "\n",
+    "import psycopg2\n",
+    "import pandas as pd \n",
+    "import numpy as np\n",
+    "from scipy import stats\n",
+    "\n",
+    "import datetime as dt\n",
+    "from dateutil.relativedelta import relativedelta\n",
+    "\n",
+    "import plotly.express as px\n",
+    "from plotly.subplots import make_subplots\n",
+    "import plotly.graph_objects as go\n",
+    "\n",
+    "import random\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connect to Augur database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# connect to db\n",
+    "with open(\"../../comm_cage.json\") as config_file:\n",
+    "    config = json.load(config_file)\n",
+    "    \n",
+    "database_connection_string = 'postgresql+psycopg2://{}:{}@{}:{}/{}'.format(config['user'], config['password'], config['host'], config['port'], config['database'])\n",
+    "\n",
+    "dbschema='augur_data'\n",
+    "engine = salc.create_engine(\n",
+    "    database_connection_string,\n",
+    "    connect_args={'options': '-csearch_path={}'.format(dbschema)})"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Query data\n",
+    "Let's first define some functions that will help us organize the data in a data frame, remove contributors that are potential bots, and count the number of contributions each individual has made.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_df(repo_query):\n",
+    "    '''\n",
+    "    :param repo_query: A string representing a SQL statement\n",
+    "    \n",
+    "    returns a DataFrame where the columns are contrb_id, their contribution type, and the commit date \n",
+    "    '''\n",
+    "    df = pd.read_sql_query(repo_query, con=engine.connect())\n",
+    "    df = df.reset_index()\n",
+    "    if 'date' in df.columns:\n",
+    "        df['date'] = pd.to_datetime(df['date'])\n",
+    "    df.drop('index', axis=1, inplace=True)\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def filter_rows(df, patterns=['bot'], colname='email'):\n",
+    "    '''\n",
+    "    :param df: A DataFrame to screen column values out of\n",
+    "    :param patterns: A list of strings or regular expression, patterns to be screened out\n",
+    "    :param colname: A string representing the name of the column to screen patterns out of\n",
+    "\n",
+    "    returns a DataFrame with columns that matched, and column used to match, dropped.\n",
+    "    '''\n",
+    "    # filter for rows in df where the column value contains any of the specifed patterns\n",
+    "    return df[~df[colname].isin(patterns)]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def count_cntrbs(df, contribution_type, patterns=['bot'], colname='email', ascending=False):\n",
+    "    '''\n",
+    "    :param df: A DataFrame \n",
+    "    :param contribution_type: A string indicating the type of contribution\n",
+    "    :param patterns: A list representing of strings or regular expression, patterns to be screened out\n",
+    "    :param colname: A string representing the name of column to screen patterns out of\n",
+    "    :param descending: A boolean indicating the order in which the returned df columns are sorted according to bus factor, \n",
+    "                      by default it is set to False which corresponds to descending order\n",
+    "\n",
+    "    returns a DataFrame of cntrb_id's and a count of each of their contributions, sorted\n",
+    "    '''\n",
+    "    # remove potential bots\n",
+    "    df = filter_rows(df, patterns, colname)\n",
+    "    # count the number of contributions per contributor \n",
+    "    df = (df.groupby('cntrb_id')[contribution_type].count()).to_frame()\n",
+    "    # sort rows according to amount of contributions\n",
+    "    df.sort_values(by=contribution_type, ascending=ascending, inplace=True)\n",
+    "    df = df.reset_index()\n",
+    "    return df"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calculate bus factor\n",
+    "\n",
+    "While the bus factor is typically defined using 50% as threshold for the percent of contributors a project can lose before it stalls, we're interested in a range of thresholds. In the following function `calc_bus_factor`, we've added a parameter `threshold` to do so.\n",
+    "\n",
+    "Additionally, we're interested in counting the number of outliers i.e individuals who make contributions significantly above average. In our implementation, we define outliers as any contributors with contributions that are 2 or more standard deviations above the mean number of commits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calc_bus_factor(df, contribution_type, threshold):\n",
+    "    '''\n",
+    "    :param df: A DataFrame of cntrb_id's and contributions, sorted in descending order of contributions\n",
+    "    :param contribution_type: A String indicating the activity of interest\n",
+    "    :param threshold: A double indicating the cut off threshold for bus factor\n",
+    "\n",
+    "    A contributor is ranked by how large of a proportion of all work they did - \n",
+    "    if someone authored 350 of 1000 commits, for instance, they'll account for 35% \n",
+    "    of the commits made. The list of percent contributions is ranked in descending order. \n",
+    "    The ordered list is greedily processed such that the smallest list of contributors is \n",
+    "    found that accounts for threshold percent of the work done for a given contribution type.\n",
+    "   \n",
+    "    returns the bus factor, cntrb_id's and number of outliers for the given contribution type\n",
+    "    '''\n",
+    "    # identify and count outliers which we define as 2 standard deviations or more above from the mean\n",
+    "    num_outliers = len(df[(stats.zscore(df[contribution_type]) > 2)])\n",
+    "  \n",
+    "    # calculate total number of contributions\n",
+    "    t_cntrbs = df[contribution_type].sum()\n",
+    "\n",
+    "    # initilize empty list of to store contibutor ids for those who make up the bus factor\n",
+    "    cntrb_ids = []\n",
+    "    # initialize cumulative percent of contributions\n",
+    "    cum_per = 0\n",
+    "\n",
+    "    # add column name cntrbs to calculate the ratio of activity to the total amount of said activity\n",
+    "    df[\"cntrbs\"] = df[contribution_type] / t_cntrbs\n",
+    "    df = df.reset_index()\n",
+    "    \n",
+    "    # iterate through each row in df and create a running sum of percent contributions\n",
+    "    for _, row in df.iterrows():\n",
+    "        cum_per += row['cntrbs']\n",
+    "        cntrb_ids.append(row['cntrb_id']) # add contributor id to list \n",
+    "        # if the cumulative percent of contributions is greater than or equal to the threshold, break\n",
+    "        if cum_per  >= threshold:\n",
+    "            break\n",
+    "    \n",
+    "    # calculate the bus factor\n",
+    "    bus_factor = len(cntrb_ids)\n",
+    "    return bus_factor, cntrb_ids, num_outliers"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The bus factor can fluctuate over the lifetime of the project. Thus, we're interested in the analyzing the bus factor in a specific window of time and seeing how it evolves over different periods of time. We prioritize the most recent information so we create sliding windows from the end date up to and including the start date. If there is any remaining time between the start and end date, we calculate the bus factor for that slice of time, even if it is less than the window width."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def bus_factor_by_windows(df, contribution_type, window_width, step_size, threshold, start_date=None, end_date=None):\n",
+    "    ''' \n",
+    "    :param df: A DataFrame of cntrb_id's, contributions, and dates\n",
+    "    :param contribution_type: A String indicating the activity of interest\n",
+    "    :param window_width: An integer representing the window in months for which the bus factor is calculated. \n",
+    "    :param step_size:  An integer representing how many months the sliding window advances each iteration\n",
+    "    :param threshold: A double indicating the cut off threshold for bus factor\n",
+    "    :param start_date: A string representing start date of the interval, by default \n",
+    "    :param end_date: A string representing the end data of the interval\n",
+    "    \n",
+    "    returns a DataFrame of period to, period from, cntrb_id, and bus factor for the specified window_width and step_size\n",
+    "    '''\n",
+    "    # if the start date and end date are null, set them to the first and last commit date\n",
+    "    if start_date == None:\n",
+    "        start_date = str(min(df['date']).date())\n",
+    "       \n",
+    "    if end_date == None:\n",
+    "        end_date = str(max(df['date']).date())\n",
+    "    \n",
+    "    start_date = dt.datetime.strptime(start_date, \"%Y-%m-%d\")\n",
+    "    end_date = dt.datetime.strptime(end_date, \"%Y-%m-%d\")\n",
+    "    \n",
+    "    # if the window width is greater than time spanned by start date and end date, raise ValueError\n",
+    "    # convert the difference between the end date and start date into months\n",
+    "    delta_year = (end_date.year - start_date.year) \n",
+    "    delta_month = (delta_year * 12) + (end_date.month - start_date.month)\n",
+    "    if window_width > delta_month:\n",
+    "         raise ValueError('The window width cannot be greater than the time spanned by the start and end date.')\n",
+    "    \n",
+    "    # if the step size is greater than window width, raise ValueError\n",
+    "    if step_size > window_width:\n",
+    "        raise ValueError('The step size cannot be greater than the window width.')\n",
+    "     \n",
+    "    window_width=relativedelta(months=window_width)\n",
+    "    step_size=relativedelta(months=step_size)\n",
+    "\n",
+    "    bfs=[]\n",
+    "    cntrb_ids = []\n",
+    "    period_from = []\n",
+    "    period_to = [] \n",
+    "\n",
+    "    # calculate bus factor for each window, starting from the end date\n",
+    "    while True:\n",
+    "        period_from.append((end_date - window_width).strftime('%Y-%m-%d'))\n",
+    "        period_to.append(end_date.strftime('%Y-%m-%d'))\n",
+    "\n",
+    "        # index df such that its rows are between the end date - window width and end date\n",
+    "        mask = (df['date'] >= end_date - window_width) & (df['date'] <= end_date)\n",
+    "        count_cntrbs_window = count_cntrbs(df.loc[mask], contribution_type)\n",
+    "\n",
+    "        # calculate bus factor\n",
+    "        bus_factor, cntrb_id, num_outliers = calc_bus_factor(count_cntrbs_window, contribution_type, threshold)\n",
+    "        \n",
+    "        bfs.append(bus_factor)\n",
+    "        \n",
+    "        # shift the end_date by the step size\n",
+    "        end_date -= step_size\n",
+    "        \n",
+    "        # get the bus factor for the remaining slice, even if it is smaller than the window width\n",
+    "        # set flag to indicate if the remaining slice has not been calculated yet\n",
+    "        remaining_slice = False\n",
+    "        if end_date - window_width <= start_date:\n",
+    "            # calculate the remaining time between the current end date and start date, which will be the new window width\n",
+    "            last_window_width = end_date - start_date\n",
+    "            period_from.append((end_date - last_window_width).strftime('%Y-%m-%d'))\n",
+    "            period_to.append(end_date.strftime('%Y-%m-%d'))\n",
+    "\n",
+    "            # index df such that its rows are betweeen the end_date - window_width and end date\n",
+    "            remaining_mask = (df['date'] >= end_date - last_window_width) & (df['date'] <= end_date) \n",
+    "            count_cntrbs_last_window = count_cntrbs(df.loc[remaining_mask], contribution_type)\n",
+    "            # calculate bus factor for the remaining slice\n",
+    "            bus_factor, cntrb_id, num_outliers = calc_bus_factor(count_cntrbs_last_window, contribution_type, threshold)\n",
+    "            bfs.append(bus_factor)\n",
+    "            # set flag to True, indicating that the bus factor for the remaining slice has been calculated\n",
+    "            remaining_slice = True\n",
+    "\n",
+    "        # exit loop if the remaining slice has been calculated\n",
+    "        if remaining_slice:\n",
+    "            break\n",
+    "        \n",
+    "    # create a dataframe with period to, period from, bus factor, and cntrb_ids as columns\n",
+    "    df = pd.DataFrame(list(zip(period_from, period_to, bfs)), columns = ['period_from', 'period_to', 'bus_factor'])\n",
+    "    return df"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We often visualize data to get a better of understanding of it. Let's plot a line chart depicting the data generated by `bus_factor_by_windows`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_line_graph(df, title, xlabel, ylabel, step_size):\n",
+    "    '''\n",
+    "    :param df: A DataFrame that has period_from and bus_factor as its columns\n",
+    "    :param title: A String describing the context of the plot\n",
+    "    :param xlabel: A String assigned to the x-axis label\n",
+    "    :param ylabel: A String assigned to the y-axis label\n",
+    "    :param step_size: An integer representing how many months the sliding window advances each iteration\n",
+    "\n",
+    "    returns a line graph of bus factor vs time\n",
+    "    '''\n",
+    "    fig = px.line(df, x=\"period_from\", y=\"bus_factor\", custom_data=[\"period_to\"], text=\"bus_factor\", width=800, height=500)\n",
+    "    \n",
+    "    fig.update_xaxes(fixedrange=True, tickformat=\"%B %Y\", tickangle=45, dtick=f\"M{step_size}\")\n",
+    "\n",
+    "    start_date = min(df['period_from'])\n",
+    "    fig.update_layout(title={'text':title,'x':0.5, 'xanchor':'center'},\n",
+    "                   xaxis_title=xlabel,\n",
+    "                   xaxis=dict(tick0=start_date),\n",
+    "                   yaxis_title=ylabel \n",
+    "                )\n",
+    "    \n",
+    "    hovertemplate=\"<br>\".join([\"period from: %{x: %m-%d}\", \"period to: %{customdata[0]: %m-%d}\"])\n",
+    "    fig.update_traces(textposition=\"top right\", hovertemplate=hovertemplate, line_color=\"lightgreen\")\n",
+    "\n",
+    "    fig.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have all of our functions defined, let's put them to practice!"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bus factor by number of commits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repo_name = 'Ansible'\n",
+    "repo_statement = str([28336])\n",
+    "repo_statement = repo_statement[1:-1]\n",
+    "\n",
+    "repo_query = salc.sql.text(f\"\"\"\n",
+    "                SELECT\n",
+    "                   DISTINCT c.cmt_commit_hash AS commit,\n",
+    "                   ca.cntrb_id, \n",
+    "                   c.cmt_author_email AS email,\n",
+    "                   c.cmt_author_date AS date        \n",
+    "                FROM\n",
+    "                    contributors_aliases ca\n",
+    "                JOIN \n",
+    "                    commits c \n",
+    "                ON \n",
+    "                    c.cmt_committer_email = ca.alias_email\n",
+    "                WHERE\n",
+    "                    c.repo_id in({repo_statement})\n",
+    "               \"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>commit</th>\n",
+       "      <th>cntrb_id</th>\n",
+       "      <th>email</th>\n",
+       "      <th>date</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>bc6623556315022aa84d0b01d8bd91bcf3d65526</td>\n",
+       "      <td>01000067-2300-0000-0000-000000000000</td>\n",
+       "      <td>jimi@sngx.net</td>\n",
+       "      <td>2014-08-25</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>14f0fd9ab361331cac2ba9a660f86d4b4e95e8a3</td>\n",
+       "      <td>0100005d-0100-0000-0000-000000000000</td>\n",
+       "      <td>35260522+ilicmilan@users.noreply.github.com</td>\n",
+       "      <td>2018-05-25</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>995d7e4db30ff1574d0db181b6ebe9868b2853a2</td>\n",
+       "      <td>01000c4d-d800-0000-0000-000000000000</td>\n",
+       "      <td>matt@mystile.com</td>\n",
+       "      <td>2022-01-31</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>e8aaed3bbb9d29130dbe645fca9521af7b305aca</td>\n",
+       "      <td>01000c4d-d800-0000-0000-000000000000</td>\n",
+       "      <td>chrrrles@users.noreply.github.com</td>\n",
+       "      <td>2015-09-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>948682dbe20a693c011f4fde5604debeafd3a524</td>\n",
+       "      <td>01000067-2300-0000-0000-000000000000</td>\n",
+       "      <td>jimi@sngx.net</td>\n",
+       "      <td>2016-06-23</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                     commit  \\\n",
+       "0  bc6623556315022aa84d0b01d8bd91bcf3d65526   \n",
+       "1  14f0fd9ab361331cac2ba9a660f86d4b4e95e8a3   \n",
+       "2  995d7e4db30ff1574d0db181b6ebe9868b2853a2   \n",
+       "3  e8aaed3bbb9d29130dbe645fca9521af7b305aca   \n",
+       "4  948682dbe20a693c011f4fde5604debeafd3a524   \n",
+       "\n",
+       "                               cntrb_id  \\\n",
+       "0  01000067-2300-0000-0000-000000000000   \n",
+       "1  0100005d-0100-0000-0000-000000000000   \n",
+       "2  01000c4d-d800-0000-0000-000000000000   \n",
+       "3  01000c4d-d800-0000-0000-000000000000   \n",
+       "4  01000067-2300-0000-0000-000000000000   \n",
+       "\n",
+       "                                         email       date  \n",
+       "0                                jimi@sngx.net 2014-08-25  \n",
+       "1  35260522+ilicmilan@users.noreply.github.com 2018-05-25  \n",
+       "2                             matt@mystile.com 2022-01-31  \n",
+       "3            chrrrles@users.noreply.github.com 2015-09-01  \n",
+       "4                                jimi@sngx.net 2016-06-23  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# organize commits data in a DataFrame\n",
+    "conn_commits = get_df(repo_query)\n",
+    "display(conn_commits.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>cntrb_id</th>\n",
+       "      <th>commit</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>01012f1b-7f00-0000-0000-000000000000</td>\n",
+       "      <td>10092</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>01000c4d-d800-0000-0000-000000000000</td>\n",
+       "      <td>7774</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>01022886-a200-0000-0000-000000000000</td>\n",
+       "      <td>5289</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>01000cc2-4b00-0000-0000-000000000000</td>\n",
+       "      <td>4233</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>01000067-2300-0000-0000-000000000000</td>\n",
+       "      <td>2896</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                               cntrb_id  commit\n",
+       "0  01012f1b-7f00-0000-0000-000000000000   10092\n",
+       "1  01000c4d-d800-0000-0000-000000000000    7774\n",
+       "2  01022886-a200-0000-0000-000000000000    5289\n",
+       "3  01000cc2-4b00-0000-0000-000000000000    4233\n",
+       "4  01000067-2300-0000-0000-000000000000    2896"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# count the number of commits per contributor and order the rows from most to least number of commits\n",
+    "commits = count_cntrbs(df=conn_commits, contribution_type='commit', patterns=['bot'], colname='email')\n",
+    "# display the top 5 most active contributors\n",
+    "display(commits.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The bus factor in terms of number of commits for Ansible is 4.\n",
+      "Of the total number of contributors, 7 were identified as outliers.\n"
+     ]
+    }
+   ],
+   "source": [
+    "bf_commits, cntrb_ids, num_outliers = calc_bus_factor(df=commits, contribution_type='commit', threshold=0.50)\n",
+    "print(f'The bus factor in terms of number of commits for {repo_name} is {bf_commits}.\\nOf the total number of contributors, {num_outliers} were identified as outliers.')"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's analyze how the bus factor has evolved over the entire lifetime of the Ansible by taking window sizes of 6 months and sliding by a step size of 4 months."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>period_from</th>\n",
+       "      <th>period_to</th>\n",
+       "      <th>bus_factor</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2022-11-10</td>\n",
+       "      <td>2023-05-10</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2022-07-10</td>\n",
+       "      <td>2023-01-10</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2022-03-10</td>\n",
+       "      <td>2022-09-10</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2021-11-10</td>\n",
+       "      <td>2022-05-10</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2021-07-10</td>\n",
+       "      <td>2022-01-10</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  period_from   period_to  bus_factor\n",
+       "0  2022-11-10  2023-05-10           1\n",
+       "1  2022-07-10  2023-01-10           1\n",
+       "2  2022-03-10  2022-09-10           1\n",
+       "3  2021-11-10  2022-05-10           1\n",
+       "4  2021-07-10  2022-01-10           1"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "commits_bf_by_windows = bus_factor_by_windows(df=conn_commits, contribution_type='commit', window_width=6, step_size=4, threshold=0.5)\n",
+    "display(commits_bf_by_windows.head())"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to get a better sense of how the bus factor has evolved overtime, let's plot a line graph!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "customdata": [
+          [
+           "2023-05-10"
+          ],
+          [
+           "2023-01-10"
+          ],
+          [
+           "2022-09-10"
+          ],
+          [
+           "2022-05-10"
+          ],
+          [
+           "2022-01-10"
+          ],
+          [
+           "2021-09-10"
+          ],
+          [
+           "2021-05-10"
+          ],
+          [
+           "2021-01-10"
+          ],
+          [
+           "2020-09-10"
+          ],
+          [
+           "2020-05-10"
+          ],
+          [
+           "2020-01-10"
+          ],
+          [
+           "2019-09-10"
+          ],
+          [
+           "2019-05-10"
+          ],
+          [
+           "2019-01-10"
+          ],
+          [
+           "2018-09-10"
+          ],
+          [
+           "2018-05-10"
+          ],
+          [
+           "2018-01-10"
+          ],
+          [
+           "2017-09-10"
+          ],
+          [
+           "2017-05-10"
+          ],
+          [
+           "2017-01-10"
+          ],
+          [
+           "2016-09-10"
+          ],
+          [
+           "2016-05-10"
+          ],
+          [
+           "2016-01-10"
+          ],
+          [
+           "2015-09-10"
+          ],
+          [
+           "2015-05-10"
+          ],
+          [
+           "2015-01-10"
+          ],
+          [
+           "2014-09-10"
+          ],
+          [
+           "2014-05-10"
+          ],
+          [
+           "2014-01-10"
+          ],
+          [
+           "2013-09-10"
+          ],
+          [
+           "2013-05-10"
+          ],
+          [
+           "2013-01-10"
+          ],
+          [
+           "2012-09-10"
+          ],
+          [
+           "2012-05-10"
+          ]
+         ],
+         "hovertemplate": "period from: %{x: %m-%d}<br>period to: %{customdata[0]: %m-%d}",
+         "legendgroup": "",
+         "line": {
+          "color": "lightgreen",
+          "dash": "solid"
+         },
+         "marker": {
+          "symbol": "circle"
+         },
+         "mode": "text+markers+lines",
+         "name": "",
+         "orientation": "v",
+         "showlegend": false,
+         "text": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          5,
+          5,
+          3,
+          3,
+          4,
+          3,
+          3,
+          4,
+          3,
+          2,
+          2,
+          2,
+          2,
+          2,
+          2,
+          3,
+          2,
+          3,
+          3,
+          1,
+          1,
+          1,
+          1,
+          1
+         ],
+         "textposition": "top right",
+         "type": "scatter",
+         "x": [
+          "2022-11-10",
+          "2022-07-10",
+          "2022-03-10",
+          "2021-11-10",
+          "2021-07-10",
+          "2021-03-10",
+          "2020-11-10",
+          "2020-07-10",
+          "2020-03-10",
+          "2019-11-10",
+          "2019-07-10",
+          "2019-03-10",
+          "2018-11-10",
+          "2018-07-10",
+          "2018-03-10",
+          "2017-11-10",
+          "2017-07-10",
+          "2017-03-10",
+          "2016-11-10",
+          "2016-07-10",
+          "2016-03-10",
+          "2015-11-10",
+          "2015-07-10",
+          "2015-03-10",
+          "2014-11-10",
+          "2014-07-10",
+          "2014-03-10",
+          "2013-11-10",
+          "2013-07-10",
+          "2013-03-10",
+          "2012-11-10",
+          "2012-07-10",
+          "2012-03-10",
+          "2012-02-05"
+         ],
+         "xaxis": "x",
+         "y": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          5,
+          5,
+          3,
+          3,
+          4,
+          3,
+          3,
+          4,
+          3,
+          2,
+          2,
+          2,
+          2,
+          2,
+          2,
+          3,
+          2,
+          3,
+          3,
+          1,
+          1,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "legend": {
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Bus Factor of Commits in 6 Month Periods",
+         "x": 0.5,
+         "xanchor": "center"
+        },
+        "width": 800,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "dtick": "M4",
+         "fixedrange": true,
+         "tick0": "2012-02-05",
+         "tickangle": 45,
+         "tickformat": "%B %Y",
+         "title": {
+          "text": "Timeline (stepsize = 4 months)"
+         }
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "text": "Bus Factor"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_line_graph(df=commits_bf_by_windows, \n",
+    "               title='Bus Factor of Commits in 6 Month Periods', \n",
+    "               xlabel='Timeline (stepsize = 4 months)',\n",
+    "               ylabel='Bus Factor', \n",
+    "               step_size=4)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we've analyzed the bus factor for one type of contribution to a project, let's explore others. Not only are contributors individuals who have directly committed to the project but also those who have contributed by creating issues."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bus factor by number of issues"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's analyze the bus factor for the number of issues created."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>issue</th>\n",
+       "      <th>cntrb_id</th>\n",
+       "      <th>email</th>\n",
+       "      <th>date</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1309542</td>\n",
+       "      <td>01003fef-7900-0000-0000-000000000000</td>\n",
+       "      <td>xenlaurent@gmail.com</td>\n",
+       "      <td>2018-12-20 13:25:16</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1297754</td>\n",
+       "      <td>010009e9-b000-0000-0000-000000000000</td>\n",
+       "      <td>kcase@redhat.com</td>\n",
+       "      <td>2017-10-24 15:47:14</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1304703</td>\n",
+       "      <td>01005837-6c00-0000-0000-000000000000</td>\n",
+       "      <td>felix@fontein.de</td>\n",
+       "      <td>2019-02-16 13:10:51</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1291777</td>\n",
+       "      <td>01000c4d-d800-0000-0000-000000000000</td>\n",
+       "      <td>mclay@mclay-OSX.lan</td>\n",
+       "      <td>2019-01-22 17:57:59</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1305209</td>\n",
+       "      <td>01000364-0900-0000-0000-000000000000</td>\n",
+       "      <td>gsymons@affinipay.com</td>\n",
+       "      <td>2018-08-07 22:01:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     issue                              cntrb_id                  email  \\\n",
+       "0  1309542  01003fef-7900-0000-0000-000000000000   xenlaurent@gmail.com   \n",
+       "1  1297754  010009e9-b000-0000-0000-000000000000       kcase@redhat.com   \n",
+       "2  1304703  01005837-6c00-0000-0000-000000000000       felix@fontein.de   \n",
+       "3  1291777  01000c4d-d800-0000-0000-000000000000    mclay@mclay-OSX.lan   \n",
+       "4  1305209  01000364-0900-0000-0000-000000000000  gsymons@affinipay.com   \n",
+       "\n",
+       "                 date  \n",
+       "0 2018-12-20 13:25:16  \n",
+       "1 2017-10-24 15:47:14  \n",
+       "2 2019-02-16 13:10:51  \n",
+       "3 2019-01-22 17:57:59  \n",
+       "4 2018-08-07 22:01:00  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "issues_query = salc.sql.text(f\"\"\"\n",
+    "                SELECT\n",
+    "                    DISTINCT i.issue_id AS issue,\n",
+    "                    i.reporter_id AS cntrb_id,\n",
+    "                    ca.alias_email as email,\n",
+    "                    i.created_at AS date\n",
+    "                FROM\n",
+    "                    issues i, \n",
+    "                    contributors_aliases ca\n",
+    "                WHERE\n",
+    "                    i.repo_id in({repo_statement}) AND\n",
+    "                    i.reporter_id = ca.cntrb_id\n",
+    "               \"\"\")\n",
+    "\n",
+    "conn_issues = get_df(issues_query)\n",
+    "display(conn_issues.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>cntrb_id</th>\n",
+       "      <th>issue</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>01000331-5a00-0000-0000-000000000000</td>\n",
+       "      <td>518</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>01000e5a-0d00-0000-0000-000000000000</td>\n",
+       "      <td>507</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>01000c4d-d800-0000-0000-000000000000</td>\n",
+       "      <td>504</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>01006421-1900-0000-0000-000000000000</td>\n",
+       "      <td>480</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>010005ec-6600-0000-0000-000000000000</td>\n",
+       "      <td>436</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                               cntrb_id  issue\n",
+       "0  01000331-5a00-0000-0000-000000000000    518\n",
+       "1  01000e5a-0d00-0000-0000-000000000000    507\n",
+       "2  01000c4d-d800-0000-0000-000000000000    504\n",
+       "3  01006421-1900-0000-0000-000000000000    480\n",
+       "4  010005ec-6600-0000-0000-000000000000    436"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "issues_created = count_cntrbs(df=conn_issues, contribution_type='issue')\n",
+    "display(issues_created.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The bus factor in terms of number of issues created for Ansible is 203.\n",
+      "Of the total number of contributors, 65 were identified as outliers.\n"
+     ]
+    }
+   ],
+   "source": [
+    "bf_issues, cntrb_ids, num_outliers = calc_bus_factor(issues_created, contribution_type='issue', threshold=0.50)\n",
+    "print(f'The bus factor in terms of number of issues created for {repo_name} is {bf_issues}.\\nOf the total number of contributors, {num_outliers} were identified as outliers.')"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similar to the previous analysis, we performed on the number of commits, let's calculate the bus factor for issues created in windows of 6 months with a step size of 4 months over the entire lifetime of Ansible and plot it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>period_from</th>\n",
+       "      <th>period_to</th>\n",
+       "      <th>bus_factor</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2022-12-09</td>\n",
+       "      <td>2023-06-09</td>\n",
+       "      <td>14</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2022-08-09</td>\n",
+       "      <td>2023-02-09</td>\n",
+       "      <td>17</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2022-04-09</td>\n",
+       "      <td>2022-10-09</td>\n",
+       "      <td>23</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2021-12-09</td>\n",
+       "      <td>2022-06-09</td>\n",
+       "      <td>34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2021-08-09</td>\n",
+       "      <td>2022-02-09</td>\n",
+       "      <td>27</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  period_from   period_to  bus_factor\n",
+       "0  2022-12-09  2023-06-09          14\n",
+       "1  2022-08-09  2023-02-09          17\n",
+       "2  2022-04-09  2022-10-09          23\n",
+       "3  2021-12-09  2022-06-09          34\n",
+       "4  2021-08-09  2022-02-09          27"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "issue_bf_by_windows = bus_factor_by_windows(df=conn_issues, contribution_type='issue', window_width=6, step_size=4, threshold=0.5)\n",
+    "display(issue_bf_by_windows.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "customdata": [
+          [
+           "2023-06-09"
+          ],
+          [
+           "2023-02-09"
+          ],
+          [
+           "2022-10-09"
+          ],
+          [
+           "2022-06-09"
+          ],
+          [
+           "2022-02-09"
+          ],
+          [
+           "2021-10-09"
+          ],
+          [
+           "2021-06-09"
+          ],
+          [
+           "2021-02-09"
+          ],
+          [
+           "2020-10-09"
+          ],
+          [
+           "2020-06-09"
+          ],
+          [
+           "2020-02-09"
+          ],
+          [
+           "2019-10-09"
+          ],
+          [
+           "2019-06-09"
+          ],
+          [
+           "2019-02-09"
+          ],
+          [
+           "2018-10-09"
+          ],
+          [
+           "2018-06-09"
+          ],
+          [
+           "2018-02-09"
+          ],
+          [
+           "2017-10-09"
+          ],
+          [
+           "2017-06-09"
+          ],
+          [
+           "2017-02-09"
+          ],
+          [
+           "2016-10-09"
+          ],
+          [
+           "2016-06-09"
+          ],
+          [
+           "2016-02-09"
+          ],
+          [
+           "2015-10-09"
+          ],
+          [
+           "2015-06-09"
+          ],
+          [
+           "2015-02-09"
+          ],
+          [
+           "2014-10-09"
+          ],
+          [
+           "2014-06-09"
+          ],
+          [
+           "2014-02-09"
+          ],
+          [
+           "2013-10-09"
+          ],
+          [
+           "2013-06-09"
+          ],
+          [
+           "2013-02-09"
+          ],
+          [
+           "2012-10-09"
+          ],
+          [
+           "2012-06-09"
+          ]
+         ],
+         "hovertemplate": "period from: %{x: %m-%d}<br>period to: %{customdata[0]: %m-%d}",
+         "legendgroup": "",
+         "line": {
+          "color": "lightgreen",
+          "dash": "solid"
+         },
+         "marker": {
+          "symbol": "circle"
+         },
+         "mode": "text+markers+lines",
+         "name": "",
+         "orientation": "v",
+         "showlegend": false,
+         "text": [
+          14,
+          17,
+          23,
+          34,
+          27,
+          21,
+          26,
+          37,
+          42,
+          52,
+          36,
+          30,
+          53,
+          54,
+          72,
+          67,
+          60,
+          49,
+          73,
+          50,
+          64,
+          73,
+          52,
+          48,
+          64,
+          59,
+          62,
+          58,
+          39,
+          32,
+          14,
+          8,
+          7,
+          6
+         ],
+         "textposition": "top right",
+         "type": "scatter",
+         "x": [
+          "2022-12-09",
+          "2022-08-09",
+          "2022-04-09",
+          "2021-12-09",
+          "2021-08-09",
+          "2021-04-09",
+          "2020-12-09",
+          "2020-08-09",
+          "2020-04-09",
+          "2019-12-09",
+          "2019-08-09",
+          "2019-04-09",
+          "2018-12-09",
+          "2018-08-09",
+          "2018-04-09",
+          "2017-12-09",
+          "2017-08-09",
+          "2017-04-09",
+          "2016-12-09",
+          "2016-08-09",
+          "2016-04-09",
+          "2015-12-09",
+          "2015-08-09",
+          "2015-04-09",
+          "2014-12-09",
+          "2014-08-09",
+          "2014-04-09",
+          "2013-12-09",
+          "2013-08-09",
+          "2013-04-09",
+          "2012-12-09",
+          "2012-08-09",
+          "2012-04-09",
+          "2012-03-07"
+         ],
+         "xaxis": "x",
+         "y": [
+          14,
+          17,
+          23,
+          34,
+          27,
+          21,
+          26,
+          37,
+          42,
+          52,
+          36,
+          30,
+          53,
+          54,
+          72,
+          67,
+          60,
+          49,
+          73,
+          50,
+          64,
+          73,
+          52,
+          48,
+          64,
+          59,
+          62,
+          58,
+          39,
+          32,
+          14,
+          8,
+          7,
+          6
+         ],
+         "yaxis": "y"
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "legend": {
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Bus Factor of Issues Created in 6 Month Windows",
+         "x": 0.5,
+         "xanchor": "center"
+        },
+        "width": 800,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "dtick": "M4",
+         "fixedrange": true,
+         "tick0": "2012-03-07",
+         "tickangle": 45,
+         "tickformat": "%B %Y",
+         "title": {
+          "text": "Timeline (stepsize = 4 months)"
+         }
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "text": "Bus Factor"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_line_graph(df=issue_bf_by_windows, \n",
+    "               title='Bus Factor of Issues Created in 6 Month Windows',\n",
+    "               xlabel='Timeline (stepsize = 4 months)', \n",
+    "               ylabel='Bus Factor', \n",
+    "               step_size=4)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can further extend our notion of bus factor by number of PRs. Here we calculate bus factor seperately for contributors who have created PRs, contributors who have reviewed PRs, and individuals who have contributed to conversation around PRs."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bus factor by number of PRs\n",
+    "- Created PRs\n",
+    "- Reviewed PRs\n",
+    "- Made comments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pr</th>\n",
+       "      <th>cntrb_id</th>\n",
+       "      <th>email</th>\n",
+       "      <th>date</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1559165</td>\n",
+       "      <td>01000111-da00-0000-0000-000000000000</td>\n",
+       "      <td>ssato@src.gnome.org</td>\n",
+       "      <td>2021-07-16 19:39:22</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>3667473</td>\n",
+       "      <td>010054a4-fa00-0000-0000-000000000000</td>\n",
+       "      <td>8125011+proteriax@users.noreply.github.com</td>\n",
+       "      <td>2014-09-09 07:39:55</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1559367</td>\n",
+       "      <td>010009b6-c200-0000-0000-000000000000</td>\n",
+       "      <td>sb@ryansb.com</td>\n",
+       "      <td>2018-09-27 19:28:01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1574961</td>\n",
+       "      <td>01000a6e-0c00-0000-0000-000000000000</td>\n",
+       "      <td>patryk.d.cichy@gmail.com</td>\n",
+       "      <td>2019-03-29 06:15:48</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1554735</td>\n",
+       "      <td>01000cc2-4b00-0000-0000-000000000000</td>\n",
+       "      <td>briancoca+dev@gmail.com</td>\n",
+       "      <td>2021-04-21 21:31:24</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        pr                              cntrb_id  \\\n",
+       "0  1559165  01000111-da00-0000-0000-000000000000   \n",
+       "1  3667473  010054a4-fa00-0000-0000-000000000000   \n",
+       "2  1559367  010009b6-c200-0000-0000-000000000000   \n",
+       "3  1574961  01000a6e-0c00-0000-0000-000000000000   \n",
+       "4  1554735  01000cc2-4b00-0000-0000-000000000000   \n",
+       "\n",
+       "                                        email                date  \n",
+       "0                         ssato@src.gnome.org 2021-07-16 19:39:22  \n",
+       "1  8125011+proteriax@users.noreply.github.com 2014-09-09 07:39:55  \n",
+       "2                               sb@ryansb.com 2018-09-27 19:28:01  \n",
+       "3                    patryk.d.cichy@gmail.com 2019-03-29 06:15:48  \n",
+       "4                     briancoca+dev@gmail.com 2021-04-21 21:31:24  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pr_create_query = salc.sql.text(f\"\"\"\n",
+    "                    SELECT \n",
+    "                        DISTINCT pr.pull_request_id as pr, \n",
+    "                        pr.pr_augur_contributor_id AS cntrb_id, \n",
+    "                        ca.alias_email as email, \n",
+    "                        pr.pr_created_at as date\n",
+    "                    FROM\n",
+    "                        repo r,\n",
+    "                        pull_requests pr, \n",
+    "                        contributors_aliases ca\n",
+    "                    WHERE\n",
+    "                        r.repo_id in({repo_statement}) AND\n",
+    "                        pr.repo_id = r.repo_id AND\n",
+    "                        pr.pr_augur_contributor_id = ca.cntrb_id\n",
+    "            \"\"\")\n",
+    "\n",
+    "conn_pr_created = get_df(pr_create_query)\n",
+    "display(conn_pr_created.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>cntrb_id</th>\n",
+       "      <th>pr</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>01000cc2-4b00-0000-0000-000000000000</td>\n",
+       "      <td>11532</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>01000c4d-d800-0000-0000-000000000000</td>\n",
+       "      <td>8763</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>01000331-5a00-0000-0000-000000000000</td>\n",
+       "      <td>6293</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>01008121-3500-0000-0000-000000000000</td>\n",
+       "      <td>3600</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>01000653-a200-0000-0000-000000000000</td>\n",
+       "      <td>3392</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                               cntrb_id     pr\n",
+       "0  01000cc2-4b00-0000-0000-000000000000  11532\n",
+       "1  01000c4d-d800-0000-0000-000000000000   8763\n",
+       "2  01000331-5a00-0000-0000-000000000000   6293\n",
+       "3  01008121-3500-0000-0000-000000000000   3600\n",
+       "4  01000653-a200-0000-0000-000000000000   3392"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pr_created = count_cntrbs(df=conn_pr_created, contribution_type='pr')\n",
+    "display(pr_created.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The bus factor in terms of contributors who created PRs Ansible is 17.\n",
+      "Of the total number of contributors, 37 were identified as outliers.\n"
+     ]
+    }
+   ],
+   "source": [
+    "bf_pr_created, cntrb_ids, num_outliers = calc_bus_factor(df=pr_created, contribution_type='pr', threshold=0.50)\n",
+    "print(f'The bus factor in terms of contributors who created PRs {repo_name} is {bf_pr_created}.\\nOf the total number of contributors, {num_outliers} were identified as outliers.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>period_from</th>\n",
+       "      <th>period_to</th>\n",
+       "      <th>bus_factor</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2022-12-12</td>\n",
+       "      <td>2023-06-12</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2022-08-12</td>\n",
+       "      <td>2023-02-12</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2022-04-12</td>\n",
+       "      <td>2022-10-12</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2021-12-12</td>\n",
+       "      <td>2022-06-12</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2021-08-12</td>\n",
+       "      <td>2022-02-12</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  period_from   period_to  bus_factor\n",
+       "0  2022-12-12  2023-06-12           2\n",
+       "1  2022-08-12  2023-02-12           3\n",
+       "2  2022-04-12  2022-10-12           3\n",
+       "3  2021-12-12  2022-06-12           2\n",
+       "4  2021-08-12  2022-02-12           2"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pr_created_bf_by_windows = bus_factor_by_windows(df=conn_pr_created, contribution_type='pr', window_width=6, step_size=4, threshold=0.5)\n",
+    "display(pr_created_bf_by_windows.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "customdata": [
+          [
+           "2023-06-12"
+          ],
+          [
+           "2023-02-12"
+          ],
+          [
+           "2022-10-12"
+          ],
+          [
+           "2022-06-12"
+          ],
+          [
+           "2022-02-12"
+          ],
+          [
+           "2021-10-12"
+          ],
+          [
+           "2021-06-12"
+          ],
+          [
+           "2021-02-12"
+          ],
+          [
+           "2020-10-12"
+          ],
+          [
+           "2020-06-12"
+          ],
+          [
+           "2020-02-12"
+          ],
+          [
+           "2019-10-12"
+          ],
+          [
+           "2019-06-12"
+          ],
+          [
+           "2019-02-12"
+          ],
+          [
+           "2018-10-12"
+          ],
+          [
+           "2018-06-12"
+          ],
+          [
+           "2018-02-12"
+          ],
+          [
+           "2017-10-12"
+          ],
+          [
+           "2017-06-12"
+          ],
+          [
+           "2017-02-12"
+          ],
+          [
+           "2016-10-12"
+          ],
+          [
+           "2016-06-12"
+          ],
+          [
+           "2016-02-12"
+          ],
+          [
+           "2015-10-12"
+          ],
+          [
+           "2015-06-12"
+          ],
+          [
+           "2015-02-12"
+          ],
+          [
+           "2014-10-12"
+          ],
+          [
+           "2014-06-12"
+          ],
+          [
+           "2014-02-12"
+          ],
+          [
+           "2013-10-12"
+          ],
+          [
+           "2013-06-12"
+          ],
+          [
+           "2013-02-12"
+          ],
+          [
+           "2012-10-12"
+          ],
+          [
+           "2012-06-12"
+          ]
+         ],
+         "hovertemplate": "period from: %{x: %m-%d}<br>period to: %{customdata[0]: %m-%d}",
+         "legendgroup": "",
+         "line": {
+          "color": "lightgreen",
+          "dash": "solid"
+         },
+         "marker": {
+          "symbol": "circle"
+         },
+         "mode": "text+markers+lines",
+         "name": "",
+         "orientation": "v",
+         "showlegend": false,
+         "text": [
+          2,
+          3,
+          3,
+          2,
+          2,
+          3,
+          4,
+          5,
+          6,
+          9,
+          11,
+          11,
+          12,
+          12,
+          13,
+          13,
+          11,
+          10,
+          8,
+          6,
+          4,
+          5,
+          7,
+          8,
+          5,
+          11,
+          31,
+          21,
+          18,
+          17,
+          12,
+          6,
+          7,
+          4
+         ],
+         "textposition": "top right",
+         "type": "scatter",
+         "x": [
+          "2022-12-12",
+          "2022-08-12",
+          "2022-04-12",
+          "2021-12-12",
+          "2021-08-12",
+          "2021-04-12",
+          "2020-12-12",
+          "2020-08-12",
+          "2020-04-12",
+          "2019-12-12",
+          "2019-08-12",
+          "2019-04-12",
+          "2018-12-12",
+          "2018-08-12",
+          "2018-04-12",
+          "2017-12-12",
+          "2017-08-12",
+          "2017-04-12",
+          "2016-12-12",
+          "2016-08-12",
+          "2016-04-12",
+          "2015-12-12",
+          "2015-08-12",
+          "2015-04-12",
+          "2014-12-12",
+          "2014-08-12",
+          "2014-04-12",
+          "2013-12-12",
+          "2013-08-12",
+          "2013-04-12",
+          "2012-12-12",
+          "2012-08-12",
+          "2012-04-12",
+          "2012-03-07"
+         ],
+         "xaxis": "x",
+         "y": [
+          2,
+          3,
+          3,
+          2,
+          2,
+          3,
+          4,
+          5,
+          6,
+          9,
+          11,
+          11,
+          12,
+          12,
+          13,
+          13,
+          11,
+          10,
+          8,
+          6,
+          4,
+          5,
+          7,
+          8,
+          5,
+          11,
+          31,
+          21,
+          18,
+          17,
+          12,
+          6,
+          7,
+          4
+         ],
+         "yaxis": "y"
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "legend": {
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Bus Factor of PRs Created in 6 Month Windows",
+         "x": 0.5,
+         "xanchor": "center"
+        },
+        "width": 800,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "dtick": "M4",
+         "fixedrange": true,
+         "tick0": "2012-03-07",
+         "tickangle": 45,
+         "tickformat": "%B %Y",
+         "title": {
+          "text": "Timeline (step size = 4 months)"
+         }
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "text": "Bus Factor"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_line_graph(df=pr_created_bf_by_windows, \n",
+    "               title='Bus Factor of PRs Created in 6 Month Windows',\n",
+    "               xlabel='Timeline (step size = 4 months)', \n",
+    "               ylabel='Bus Factor', \n",
+    "               step_size=4)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's repeat the process for reviewers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pr</th>\n",
+       "      <th>cntrb_id</th>\n",
+       "      <th>email</th>\n",
+       "      <th>date</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1567530</td>\n",
+       "      <td>01000096-0900-0000-0000-000000000000</td>\n",
+       "      <td>nathanhyde@gmail.com</td>\n",
+       "      <td>2022-07-13 16:12:21</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1572389</td>\n",
+       "      <td>01006763-cc00-0000-0000-000000000000</td>\n",
+       "      <td>6775756+nitzmahone@users.noreply.github.com</td>\n",
+       "      <td>2022-08-04 19:04:45</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1572389</td>\n",
+       "      <td>01006763-cc00-0000-0000-000000000000</td>\n",
+       "      <td>mrd@redhat.com</td>\n",
+       "      <td>2022-08-04 19:04:45</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1572389</td>\n",
+       "      <td>01006763-cc00-0000-0000-000000000000</td>\n",
+       "      <td>nitzmahone@users.noreply.github.com</td>\n",
+       "      <td>2022-08-04 19:04:45</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1564357</td>\n",
+       "      <td>0101cdd9-cf00-0000-0000-000000000000</td>\n",
+       "      <td>samccann@redhat.com</td>\n",
+       "      <td>2022-07-12 19:09:24</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        pr                              cntrb_id  \\\n",
+       "0  1567530  01000096-0900-0000-0000-000000000000   \n",
+       "1  1572389  01006763-cc00-0000-0000-000000000000   \n",
+       "2  1572389  01006763-cc00-0000-0000-000000000000   \n",
+       "3  1572389  01006763-cc00-0000-0000-000000000000   \n",
+       "4  1564357  0101cdd9-cf00-0000-0000-000000000000   \n",
+       "\n",
+       "                                         email                date  \n",
+       "0                         nathanhyde@gmail.com 2022-07-13 16:12:21  \n",
+       "1  6775756+nitzmahone@users.noreply.github.com 2022-08-04 19:04:45  \n",
+       "2                               mrd@redhat.com 2022-08-04 19:04:45  \n",
+       "3          nitzmahone@users.noreply.github.com 2022-08-04 19:04:45  \n",
+       "4                          samccann@redhat.com 2022-07-12 19:09:24  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pr_review_query = salc.sql.text(f\"\"\"\n",
+    "                    SELECT \n",
+    "                        pre.pull_request_id as pr, \n",
+    "                        pre.cntrb_id, \n",
+    "                        ca.alias_email as email, \n",
+    "                        pre.created_at as date\n",
+    "                    FROM\n",
+    "                        repo r,\n",
+    "                        pull_request_events pre,  \n",
+    "                        contributors_aliases ca\n",
+    "                    WHERE\n",
+    "                        r.repo_id in({repo_statement}) AND\n",
+    "                        r.repo_id = pre.repo_id AND\n",
+    "                        pre.cntrb_id = ca.cntrb_id \n",
+    "            \"\"\")\n",
+    "\n",
+    "conn_pr_review = get_df(pr_review_query)\n",
+    "display(conn_pr_review.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>cntrb_id</th>\n",
+       "      <th>pr</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>01000c4d-d800-0000-0000-000000000000</td>\n",
+       "      <td>15486</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>01000cc2-4b00-0000-0000-000000000000</td>\n",
+       "      <td>12474</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>01006763-cc00-0000-0000-000000000000</td>\n",
+       "      <td>3816</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>01012aa8-bd00-0000-0000-000000000000</td>\n",
+       "      <td>2852</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>010008d3-ef00-0000-0000-000000000000</td>\n",
+       "      <td>2450</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                               cntrb_id     pr\n",
+       "0  01000c4d-d800-0000-0000-000000000000  15486\n",
+       "1  01000cc2-4b00-0000-0000-000000000000  12474\n",
+       "2  01006763-cc00-0000-0000-000000000000   3816\n",
+       "3  01012aa8-bd00-0000-0000-000000000000   2852\n",
+       "4  010008d3-ef00-0000-0000-000000000000   2450"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pr_reviewed = count_cntrbs(conn_pr_review, contribution_type='pr')\n",
+    "display(pr_reviewed.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The bus factor in terms of reviewers who reviewed PRs for Ansible is 2.\n",
+      "Of the total number of contributors, 8 were identified as outliers.\n"
+     ]
+    }
+   ],
+   "source": [
+    "bf_pr_reviwed, cntrb_ids, num_outliers = calc_bus_factor(pr_reviewed, contribution_type='pr', threshold=0.50)\n",
+    "print(f'The bus factor in terms of reviewers who reviewed PRs for {repo_name} is {bf_pr_reviwed}.\\nOf the total number of contributors, {num_outliers} were identified as outliers.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>period_from</th>\n",
+       "      <th>period_to</th>\n",
+       "      <th>bus_factor</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2022-12-12</td>\n",
+       "      <td>2023-06-12</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2022-08-12</td>\n",
+       "      <td>2023-02-12</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2022-04-12</td>\n",
+       "      <td>2022-10-12</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2021-12-12</td>\n",
+       "      <td>2022-06-12</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2021-12-07</td>\n",
+       "      <td>2022-02-12</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  period_from   period_to  bus_factor\n",
+       "0  2022-12-12  2023-06-12           2\n",
+       "1  2022-08-12  2023-02-12           3\n",
+       "2  2022-04-12  2022-10-12           3\n",
+       "3  2021-12-12  2022-06-12           2\n",
+       "4  2021-12-07  2022-02-12           2"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pr_reviewed_bf_by_windows = bus_factor_by_windows(conn_pr_review, contribution_type='pr', threshold=0.50, window_width=6, step_size=4)\n",
+    "display(pr_reviewed_bf_by_windows.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "customdata": [
+          [
+           "2023-06-12"
+          ],
+          [
+           "2023-02-12"
+          ],
+          [
+           "2022-10-12"
+          ],
+          [
+           "2022-06-12"
+          ],
+          [
+           "2022-02-12"
+          ]
+         ],
+         "hovertemplate": "period from: %{x: %m-%d}<br>period to: %{customdata[0]: %m-%d}",
+         "legendgroup": "",
+         "line": {
+          "color": "lightgreen",
+          "dash": "solid"
+         },
+         "marker": {
+          "symbol": "circle"
+         },
+         "mode": "text+markers+lines",
+         "name": "",
+         "orientation": "v",
+         "showlegend": false,
+         "text": [
+          2,
+          3,
+          3,
+          2,
+          2
+         ],
+         "textposition": "top right",
+         "type": "scatter",
+         "x": [
+          "2022-12-12",
+          "2022-08-12",
+          "2022-04-12",
+          "2021-12-12",
+          "2021-12-07"
+         ],
+         "xaxis": "x",
+         "y": [
+          2,
+          3,
+          3,
+          2,
+          2
+         ],
+         "yaxis": "y"
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "legend": {
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Bus Factor of PR Reviews in 6 Month Windows",
+         "x": 0.5,
+         "xanchor": "center"
+        },
+        "width": 800,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "dtick": "M4",
+         "fixedrange": true,
+         "tick0": "2021-12-07",
+         "tickangle": 45,
+         "tickformat": "%B %Y",
+         "title": {
+          "text": "Timeline (stepsize = 4 months)"
+         }
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "text": "Bus Factor"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_line_graph(df=pr_reviewed_bf_by_windows, \n",
+    "               title='Bus Factor of PR Reviews in 6 Month Windows',\n",
+    "               xlabel='Timeline (stepsize = 4 months)',\n",
+    "               ylabel='Bus Factor', \n",
+    "               step_size=4)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Not only are contributors who created and reviewed PRs integral to the health of a project. Oftentimes, commenters help facilitate the process of merging PRs by providing feedback. Thus, we are also interested in their contributions. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pr_msg</th>\n",
+       "      <th>comment_text</th>\n",
+       "      <th>cntrb_id</th>\n",
+       "      <th>email</th>\n",
+       "      <th>date</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>11789292</td>\n",
+       "      <td>The traceback failed very silently. I tried to...</td>\n",
+       "      <td>010005fa-7f00-0000-0000-000000000000</td>\n",
+       "      <td>willdthames@gmail.com</td>\n",
+       "      <td>2012-08-01 04:19:51</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>17270049</td>\n",
+       "      <td>I actually have an issue with the inventory pl...</td>\n",
+       "      <td>010000e7-9b00-0000-0000-000000000000</td>\n",
+       "      <td>franck@lumberjaph.net</td>\n",
+       "      <td>2014-03-04 15:53:37</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>24544881</td>\n",
+       "      <td>@jimi-c: Any comments on this one?\\n</td>\n",
+       "      <td>010004a8-7400-0000-0000-000000000000</td>\n",
+       "      <td>msabramo@gmail.com</td>\n",
+       "      <td>2014-11-23 18:59:19</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>11783650</td>\n",
+       "      <td>Why is _installdir_ defined in ansible_pull.ym...</td>\n",
+       "      <td>010017d7-5a00-0000-0000-000000000000</td>\n",
+       "      <td>stephenf@nero.net</td>\n",
+       "      <td>2012-09-12 22:22:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>11788498</td>\n",
+       "      <td>@rektide It's in the previous PR #2688\\n</td>\n",
+       "      <td>010005ec-6600-0000-0000-000000000000</td>\n",
+       "      <td>dag.wieers@gmail.com</td>\n",
+       "      <td>2013-04-17 22:13:12</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     pr_msg                                       comment_text  \\\n",
+       "0  11789292  The traceback failed very silently. I tried to...   \n",
+       "1  17270049  I actually have an issue with the inventory pl...   \n",
+       "2  24544881               @jimi-c: Any comments on this one?\\n   \n",
+       "3  11783650  Why is _installdir_ defined in ansible_pull.ym...   \n",
+       "4  11788498           @rektide It's in the previous PR #2688\\n   \n",
+       "\n",
+       "                               cntrb_id                  email  \\\n",
+       "0  010005fa-7f00-0000-0000-000000000000  willdthames@gmail.com   \n",
+       "1  010000e7-9b00-0000-0000-000000000000  franck@lumberjaph.net   \n",
+       "2  010004a8-7400-0000-0000-000000000000     msabramo@gmail.com   \n",
+       "3  010017d7-5a00-0000-0000-000000000000      stephenf@nero.net   \n",
+       "4  010005ec-6600-0000-0000-000000000000   dag.wieers@gmail.com   \n",
+       "\n",
+       "                 date  \n",
+       "0 2012-08-01 04:19:51  \n",
+       "1 2014-03-04 15:53:37  \n",
+       "2 2014-11-23 18:59:19  \n",
+       "3 2012-09-12 22:22:00  \n",
+       "4 2013-04-17 22:13:12  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pr_comments_query = salc.sql.text(f\"\"\"     \n",
+    "                SELECT            \n",
+    "                    DISTINCT prm.pr_msg_ref_id AS pr_msg,\n",
+    "\t\t\t\t\tm.msg_text comment_text, \n",
+    "                    m.cntrb_id,\n",
+    "                    ca.alias_email as email, \n",
+    "                    m.msg_timestamp as date\n",
+    "                FROM\n",
+    "                \trepo r,\n",
+    "                    pull_requests pr,\n",
+    "                    pull_request_message_ref prm, \n",
+    "                    message m, \n",
+    "                    contributors_aliases ca\n",
+    "                WHERE\n",
+    "                \tm.msg_id = prm.msg_id AND\n",
+    "                    prm.pull_request_id = pr.pull_request_id AND\n",
+    "                \tpr.repo_id = r.repo_id AND\n",
+    "                    r.repo_id = \\'{repo_statement}\\' AND \n",
+    "                    ca.cntrb_id = m.cntrb_id\n",
+    "        \"\"\"\n",
+    "                                \n",
+    "    )\n",
+    "conn_pr_comments = get_df(pr_comments_query)\n",
+    "display(conn_pr_comments.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>cntrb_id</th>\n",
+       "      <th>pr_msg</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>01000067-2300-0000-0000-000000000000</td>\n",
+       "      <td>3399</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>01000cc2-4b00-0000-0000-000000000000</td>\n",
+       "      <td>2064</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>010005fa-7f00-0000-0000-000000000000</td>\n",
+       "      <td>768</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>010014b6-3600-0000-0000-000000000000</td>\n",
+       "      <td>536</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>01001c87-8900-0000-0000-000000000000</td>\n",
+       "      <td>500</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                               cntrb_id  pr_msg\n",
+       "0  01000067-2300-0000-0000-000000000000    3399\n",
+       "1  01000cc2-4b00-0000-0000-000000000000    2064\n",
+       "2  010005fa-7f00-0000-0000-000000000000     768\n",
+       "3  010014b6-3600-0000-0000-000000000000     536\n",
+       "4  01001c87-8900-0000-0000-000000000000     500"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pr_comments = count_cntrbs(conn_pr_comments,'pr_msg' )\n",
+    "pr_comments.rename(columns={'pr_msg_ref_id':'pr_msg'})\n",
+    "display(pr_comments.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The bus factor in terms of number of comments on PRs for Ansible is 10.\n",
+      "Of the total number of contributors, 6 were identified as outliers.\n"
+     ]
+    }
+   ],
+   "source": [
+    "bf_pr_comments, cntrb_ids, num_outliers = calc_bus_factor(pr_comments,contribution_type='pr_msg', threshold=0.50)\n",
+    "print(f'The bus factor in terms of number of comments on PRs for {repo_name} is {bf_pr_comments}.\\nOf the total number of contributors, {num_outliers} were identified as outliers.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>period_from</th>\n",
+       "      <th>period_to</th>\n",
+       "      <th>bus_factor</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2022-12-12</td>\n",
+       "      <td>2023-06-12</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2022-08-12</td>\n",
+       "      <td>2023-02-12</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2022-04-12</td>\n",
+       "      <td>2022-10-12</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2021-12-12</td>\n",
+       "      <td>2022-06-12</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2021-08-12</td>\n",
+       "      <td>2022-02-12</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  period_from   period_to  bus_factor\n",
+       "0  2022-12-12  2023-06-12           2\n",
+       "1  2022-08-12  2023-02-12           3\n",
+       "2  2022-04-12  2022-10-12           3\n",
+       "3  2021-12-12  2022-06-12           2\n",
+       "4  2021-08-12  2022-02-12           2"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pr_comments_bf_by_windows = bus_factor_by_windows(df=conn_pr_created, contribution_type='pr', window_width=6, step_size=4, threshold=0.5)\n",
+    "display(pr_comments_bf_by_windows.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "customdata": [
+          [
+           "2023-06-12"
+          ],
+          [
+           "2023-02-12"
+          ],
+          [
+           "2022-10-12"
+          ],
+          [
+           "2022-06-12"
+          ],
+          [
+           "2022-02-12"
+          ],
+          [
+           "2021-10-12"
+          ],
+          [
+           "2021-06-12"
+          ],
+          [
+           "2021-02-12"
+          ],
+          [
+           "2020-10-12"
+          ],
+          [
+           "2020-06-12"
+          ],
+          [
+           "2020-02-12"
+          ],
+          [
+           "2019-10-12"
+          ],
+          [
+           "2019-06-12"
+          ],
+          [
+           "2019-02-12"
+          ],
+          [
+           "2018-10-12"
+          ],
+          [
+           "2018-06-12"
+          ],
+          [
+           "2018-02-12"
+          ],
+          [
+           "2017-10-12"
+          ],
+          [
+           "2017-06-12"
+          ],
+          [
+           "2017-02-12"
+          ],
+          [
+           "2016-10-12"
+          ],
+          [
+           "2016-06-12"
+          ],
+          [
+           "2016-02-12"
+          ],
+          [
+           "2015-10-12"
+          ],
+          [
+           "2015-06-12"
+          ],
+          [
+           "2015-02-12"
+          ],
+          [
+           "2014-10-12"
+          ],
+          [
+           "2014-06-12"
+          ],
+          [
+           "2014-02-12"
+          ],
+          [
+           "2013-10-12"
+          ],
+          [
+           "2013-06-12"
+          ],
+          [
+           "2013-02-12"
+          ],
+          [
+           "2012-10-12"
+          ],
+          [
+           "2012-06-12"
+          ]
+         ],
+         "hovertemplate": "period from: %{x: %m-%d}<br>period to: %{customdata[0]: %m-%d}",
+         "legendgroup": "",
+         "line": {
+          "color": "lightgreen",
+          "dash": "solid"
+         },
+         "marker": {
+          "symbol": "circle"
+         },
+         "mode": "text+markers+lines",
+         "name": "",
+         "orientation": "v",
+         "showlegend": false,
+         "text": [
+          2,
+          3,
+          3,
+          2,
+          2,
+          3,
+          4,
+          5,
+          6,
+          9,
+          11,
+          11,
+          12,
+          12,
+          13,
+          13,
+          11,
+          10,
+          8,
+          6,
+          4,
+          5,
+          7,
+          8,
+          5,
+          11,
+          31,
+          21,
+          18,
+          17,
+          12,
+          6,
+          7,
+          4
+         ],
+         "textposition": "top right",
+         "type": "scatter",
+         "x": [
+          "2022-12-12",
+          "2022-08-12",
+          "2022-04-12",
+          "2021-12-12",
+          "2021-08-12",
+          "2021-04-12",
+          "2020-12-12",
+          "2020-08-12",
+          "2020-04-12",
+          "2019-12-12",
+          "2019-08-12",
+          "2019-04-12",
+          "2018-12-12",
+          "2018-08-12",
+          "2018-04-12",
+          "2017-12-12",
+          "2017-08-12",
+          "2017-04-12",
+          "2016-12-12",
+          "2016-08-12",
+          "2016-04-12",
+          "2015-12-12",
+          "2015-08-12",
+          "2015-04-12",
+          "2014-12-12",
+          "2014-08-12",
+          "2014-04-12",
+          "2013-12-12",
+          "2013-08-12",
+          "2013-04-12",
+          "2012-12-12",
+          "2012-08-12",
+          "2012-04-12",
+          "2012-03-07"
+         ],
+         "xaxis": "x",
+         "y": [
+          2,
+          3,
+          3,
+          2,
+          2,
+          3,
+          4,
+          5,
+          6,
+          9,
+          11,
+          11,
+          12,
+          12,
+          13,
+          13,
+          11,
+          10,
+          8,
+          6,
+          4,
+          5,
+          7,
+          8,
+          5,
+          11,
+          31,
+          21,
+          18,
+          17,
+          12,
+          6,
+          7,
+          4
+         ],
+         "yaxis": "y"
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "legend": {
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Bus Factor of PR Comments in 6 Month Windows",
+         "x": 0.5,
+         "xanchor": "center"
+        },
+        "width": 800,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "dtick": "M4",
+         "fixedrange": true,
+         "tick0": "2012-03-07",
+         "tickangle": 45,
+         "tickformat": "%B %Y",
+         "title": {
+          "text": "Timeline (step size = 4 months)"
+         }
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "text": "Bus Factor"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_line_graph(df=pr_comments_bf_by_windows, \n",
+    "               title='Bus Factor of PR Comments in 6 Month Windows', \n",
+    "               xlabel='Timeline (step size = 4 months)',\n",
+    "               ylabel='Bus Factor', \n",
+    "               step_size=4)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "Up until this point, we've been analyzing each perspective on bus factor individually. Let's compare the top 10 contributors from each perspective to see if there's a trend in the most active contributors. We can do this by plotting a pie chart for each perspective."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_top_k(df,k):\n",
+    "    \"\"\"\n",
+    "    :param df: A DataFrame resulting from the count_cntrbs function\n",
+    "    :param k: An integer \n",
+    "    \n",
+    "    returns a DataFrame of the top k contributors and their contributions \n",
+    "    and the remaining contributors and their contributions\n",
+    "    \"\"\"\n",
+    "    # index df to get first k rows and remove 'cntrbs' column\n",
+    "    top_k = df.iloc[:k, :2]\n",
+    "    # convert cntrb_id from type UUID to String\n",
+    "    top_k['cntrb_id'] = top_k['cntrb_id'].apply(lambda x: str(x).split('-')[0])\n",
+    "    \n",
+    "    # sort by alpha-numeric order to make it easier to map colors to contibutors\n",
+    "    top_k = top_k.sort_values(by='cntrb_id')\n",
+    "    \n",
+    "    t_sum = df.iloc[:,1].sum() # get the number of total contributions \n",
+    "    top_k_sum = top_k.iloc[:,1].sum() # get the number of total top k contributions\n",
+    "    \n",
+    "    # calculate the remaining contributions by taking the the difference of t_sum and top_k_sum\n",
+    "    top_k.loc[len(top_k.index)] = ['other', t_sum - top_k_sum ]\n",
+    "   \n",
+    "    return top_k"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We want to easily be able to compare the top contributors accross the different perpectives in our visualization. Let's create a dictionary mapping each unqiue contributor to a color. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_color_map(top_k_set):\n",
+    "    '''\n",
+    "    :param top_k_set: A list of DataFrames with top contibutors according to each perspective\n",
+    "\n",
+    "    returns a list mapping unique contributors to unique colors\n",
+    "    '''\n",
+    "    # get all unique contributors\n",
+    "    cntrb_id_set = pd.concat(top_k_set).iloc[:, 0]\n",
+    "    cntrb_id_set = [*set(list(cntrb_id_set))]\n",
+    "\n",
+    "    # intialize list to store all colours\n",
+    "    colors = []\n",
+    "\n",
+    "    # generate colors for each contributor\n",
+    "    for _ in range(len(cntrb_id_set)):\n",
+    "        r = random.randint(0,255)\n",
+    "        g = random.randint(0,255)\n",
+    "        b = random.randint(0,255)\n",
+    "\n",
+    "        colors.append(f'rgb{r,g,b}')\n",
+    "\n",
+    "    return colors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's get the top 10 contributors and the number of their contributions for each contribution type. All the remaining number of contributions will correspond to the cntrb_id \"other\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>cntrb_id</th>\n",
+       "      <th>commit</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>01000067</td>\n",
+       "      <td>2896</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>01000331</td>\n",
+       "      <td>2656</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>010009b6</td>\n",
+       "      <td>804</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>01000c4d</td>\n",
+       "      <td>7774</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>01000cc2</td>\n",
+       "      <td>4233</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>01000d6a</td>\n",
+       "      <td>808</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>01000e5a</td>\n",
+       "      <td>2139</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>01001c87</td>\n",
+       "      <td>887</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>01012f1b</td>\n",
+       "      <td>10092</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>01022886</td>\n",
+       "      <td>5289</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>other</td>\n",
+       "      <td>13048</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    cntrb_id  commit\n",
+       "4   01000067    2896\n",
+       "5   01000331    2656\n",
+       "9   010009b6     804\n",
+       "1   01000c4d    7774\n",
+       "3   01000cc2    4233\n",
+       "8   01000d6a     808\n",
+       "6   01000e5a    2139\n",
+       "7   01001c87     887\n",
+       "0   01012f1b   10092\n",
+       "2   01022886    5289\n",
+       "10     other   13048"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# get the top 10 contributors for each contribution type\n",
+    "top_10_commits = get_top_k(commits, 10)\n",
+    "top_10_issues = get_top_k(issues_created, 10)\n",
+    "top_10_prs_created = get_top_k(pr_created, 10)\n",
+    "top_10_prs_reviewed = get_top_k(pr_reviewed, 10)\n",
+    "top_10_pr_comments = get_top_k(pr_comments, 10)\n",
+    "\n",
+    "display(top_10_commits)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "domain": {
+          "x": [
+           0,
+           0.45
+          ],
+          "y": [
+           0.7333333333333333,
+           1
+          ]
+         },
+         "hole": 0.6,
+         "hoverinfo": "label+percent",
+         "labels": [
+          "01000067",
+          "01000331",
+          "010009b6",
+          "01000c4d",
+          "01000cc2",
+          "01000d6a",
+          "01000e5a",
+          "01001c87",
+          "01012f1b",
+          "01022886",
+          "other"
+         ],
+         "marker": {
+          "colors": [
+           "rgb(82, 213, 195)",
+           "rgb(49, 73, 78)",
+           "rgb(175, 220, 215)",
+           "rgb(166, 25, 27)",
+           "rgb(178, 250, 207)",
+           "rgb(251, 45, 243)",
+           "rgb(238, 127, 34)",
+           "rgb(31, 99, 162)",
+           "rgb(77, 63, 238)",
+           "rgb(211, 14, 213)",
+           "rgb(39, 166, 111)",
+           "rgb(236, 70, 70)",
+           "rgb(119, 208, 12)",
+           "rgb(75, 231, 180)",
+           "rgb(64, 140, 126)",
+           "rgb(152, 204, 176)",
+           "rgb(94, 143, 195)",
+           "rgb(40, 204, 37)",
+           "rgb(225, 60, 89)",
+           "rgb(86, 253, 139)",
+           "rgb(149, 48, 106)",
+           "rgb(254, 213, 59)",
+           "rgb(16, 255, 154)",
+           "rgb(12, 122, 70)",
+           "rgb(110, 225, 155)",
+           "rgb(222, 185, 210)",
+           "rgb(85, 68, 142)",
+           "rgb(10, 138, 65)",
+           "rgb(247, 221, 252)",
+           "rgb(167, 126, 60)",
+           "rgb(145, 78, 145)",
+           "rgb(91, 71, 63)"
+          ]
+         },
+         "textinfo": "label",
+         "textposition": "outside",
+         "type": "pie",
+         "values": [
+          2896,
+          2656,
+          804,
+          7774,
+          4233,
+          808,
+          2139,
+          887,
+          10092,
+          5289,
+          13048
+         ]
+        },
+        {
+         "domain": {
+          "x": [
+           0,
+           0.45
+          ],
+          "y": [
+           0.7333333333333333,
+           1
+          ]
+         },
+         "hole": 0.6,
+         "hoverinfo": "label+percent",
+         "labels": [
+          "01000067",
+          "01000331",
+          "010009b6",
+          "01000c4d",
+          "01000cc2",
+          "01000d6a",
+          "01000e5a",
+          "01001c87",
+          "01012f1b",
+          "01022886",
+          "other"
+         ],
+         "textinfo": "percent",
+         "textposition": "inside",
+         "type": "pie",
+         "values": [
+          2896,
+          2656,
+          804,
+          7774,
+          4233,
+          808,
+          2139,
+          887,
+          10092,
+          5289,
+          13048
+         ]
+        },
+        {
+         "domain": {
+          "x": [
+           0.55,
+           1
+          ],
+          "y": [
+           0.7333333333333333,
+           1
+          ]
+         },
+         "hole": 0.6,
+         "hoverinfo": "label+percent",
+         "labels": [
+          "0100003b",
+          "01000190",
+          "01000331",
+          "010005ec",
+          "010005fa",
+          "01000c4d",
+          "01000cc2",
+          "01000d6a",
+          "01000e5a",
+          "01006421",
+          "other"
+         ],
+         "marker": {
+          "colors": [
+           "rgb(82, 213, 195)",
+           "rgb(49, 73, 78)",
+           "rgb(175, 220, 215)",
+           "rgb(166, 25, 27)",
+           "rgb(178, 250, 207)",
+           "rgb(251, 45, 243)",
+           "rgb(238, 127, 34)",
+           "rgb(31, 99, 162)",
+           "rgb(77, 63, 238)",
+           "rgb(211, 14, 213)",
+           "rgb(39, 166, 111)",
+           "rgb(236, 70, 70)",
+           "rgb(119, 208, 12)",
+           "rgb(75, 231, 180)",
+           "rgb(64, 140, 126)",
+           "rgb(152, 204, 176)",
+           "rgb(94, 143, 195)",
+           "rgb(40, 204, 37)",
+           "rgb(225, 60, 89)",
+           "rgb(86, 253, 139)",
+           "rgb(149, 48, 106)",
+           "rgb(254, 213, 59)",
+           "rgb(16, 255, 154)",
+           "rgb(12, 122, 70)",
+           "rgb(110, 225, 155)",
+           "rgb(222, 185, 210)",
+           "rgb(85, 68, 142)",
+           "rgb(10, 138, 65)",
+           "rgb(247, 221, 252)",
+           "rgb(167, 126, 60)",
+           "rgb(145, 78, 145)",
+           "rgb(91, 71, 63)"
+          ]
+         },
+         "textinfo": "label",
+         "textposition": "outside",
+         "type": "pie",
+         "values": [
+          288,
+          420,
+          518,
+          436,
+          324,
+          504,
+          396,
+          332,
+          507,
+          480,
+          24799
+         ]
+        },
+        {
+         "domain": {
+          "x": [
+           0.55,
+           1
+          ],
+          "y": [
+           0.7333333333333333,
+           1
+          ]
+         },
+         "hole": 0.6,
+         "hoverinfo": "label+percent",
+         "labels": [
+          "0100003b",
+          "01000190",
+          "01000331",
+          "010005ec",
+          "010005fa",
+          "01000c4d",
+          "01000cc2",
+          "01000d6a",
+          "01000e5a",
+          "01006421",
+          "other"
+         ],
+         "textinfo": "percent",
+         "textposition": "inside",
+         "type": "pie",
+         "values": [
+          288,
+          420,
+          518,
+          436,
+          324,
+          504,
+          396,
+          332,
+          507,
+          480,
+          24799
+         ]
+        },
+        {
+         "domain": {
+          "x": [
+           0,
+           0.45
+          ],
+          "y": [
+           0.36666666666666664,
+           0.6333333333333333
+          ]
+         },
+         "hole": 0.6,
+         "hoverinfo": "label+percent",
+         "labels": [
+          "01000331",
+          "010005ec",
+          "010005fa",
+          "01000653",
+          "010009e9",
+          "01000c4d",
+          "01000cc2",
+          "01003dc3",
+          "010050c1",
+          "01008121",
+          "other"
+         ],
+         "marker": {
+          "colors": [
+           "rgb(82, 213, 195)",
+           "rgb(49, 73, 78)",
+           "rgb(175, 220, 215)",
+           "rgb(166, 25, 27)",
+           "rgb(178, 250, 207)",
+           "rgb(251, 45, 243)",
+           "rgb(238, 127, 34)",
+           "rgb(31, 99, 162)",
+           "rgb(77, 63, 238)",
+           "rgb(211, 14, 213)",
+           "rgb(39, 166, 111)",
+           "rgb(236, 70, 70)",
+           "rgb(119, 208, 12)",
+           "rgb(75, 231, 180)",
+           "rgb(64, 140, 126)",
+           "rgb(152, 204, 176)",
+           "rgb(94, 143, 195)",
+           "rgb(40, 204, 37)",
+           "rgb(225, 60, 89)",
+           "rgb(86, 253, 139)",
+           "rgb(149, 48, 106)",
+           "rgb(254, 213, 59)",
+           "rgb(16, 255, 154)",
+           "rgb(12, 122, 70)",
+           "rgb(110, 225, 155)",
+           "rgb(222, 185, 210)",
+           "rgb(85, 68, 142)",
+           "rgb(10, 138, 65)",
+           "rgb(247, 221, 252)",
+           "rgb(167, 126, 60)",
+           "rgb(145, 78, 145)",
+           "rgb(91, 71, 63)"
+          ]
+         },
+         "textinfo": "label",
+         "textposition": "outside",
+         "type": "pie",
+         "values": [
+          6293,
+          2230,
+          2484,
+          3392,
+          2664,
+          8763,
+          11532,
+          2697,
+          2164,
+          3600,
+          67357
+         ]
+        },
+        {
+         "domain": {
+          "x": [
+           0,
+           0.45
+          ],
+          "y": [
+           0.36666666666666664,
+           0.6333333333333333
+          ]
+         },
+         "hole": 0.6,
+         "hoverinfo": "label+percent",
+         "labels": [
+          "01000331",
+          "010005ec",
+          "010005fa",
+          "01000653",
+          "010009e9",
+          "01000c4d",
+          "01000cc2",
+          "01003dc3",
+          "010050c1",
+          "01008121",
+          "other"
+         ],
+         "textinfo": "percent",
+         "textposition": "inside",
+         "type": "pie",
+         "values": [
+          6293,
+          2230,
+          2484,
+          3392,
+          2664,
+          8763,
+          11532,
+          2697,
+          2164,
+          3600,
+          67357
+         ]
+        },
+        {
+         "domain": {
+          "x": [
+           0.55,
+           1
+          ],
+          "y": [
+           0.36666666666666664,
+           0.6333333333333333
+          ]
+         },
+         "hole": 0.6,
+         "hoverinfo": "label+percent",
+         "labels": [
+          "01000099",
+          "010008d3",
+          "01000c4d",
+          "01000cc2",
+          "0100128c",
+          "010038b7",
+          "01006763",
+          "01008121",
+          "01012aa8",
+          "0101cdd9",
+          "other"
+         ],
+         "marker": {
+          "colors": [
+           "rgb(82, 213, 195)",
+           "rgb(49, 73, 78)",
+           "rgb(175, 220, 215)",
+           "rgb(166, 25, 27)",
+           "rgb(178, 250, 207)",
+           "rgb(251, 45, 243)",
+           "rgb(238, 127, 34)",
+           "rgb(31, 99, 162)",
+           "rgb(77, 63, 238)",
+           "rgb(211, 14, 213)",
+           "rgb(39, 166, 111)",
+           "rgb(236, 70, 70)",
+           "rgb(119, 208, 12)",
+           "rgb(75, 231, 180)",
+           "rgb(64, 140, 126)",
+           "rgb(152, 204, 176)",
+           "rgb(94, 143, 195)",
+           "rgb(40, 204, 37)",
+           "rgb(225, 60, 89)",
+           "rgb(86, 253, 139)",
+           "rgb(149, 48, 106)",
+           "rgb(254, 213, 59)",
+           "rgb(16, 255, 154)",
+           "rgb(12, 122, 70)",
+           "rgb(110, 225, 155)",
+           "rgb(222, 185, 210)",
+           "rgb(85, 68, 142)",
+           "rgb(10, 138, 65)",
+           "rgb(247, 221, 252)",
+           "rgb(167, 126, 60)",
+           "rgb(145, 78, 145)",
+           "rgb(91, 71, 63)"
+          ]
+         },
+         "textinfo": "label",
+         "textposition": "outside",
+         "type": "pie",
+         "values": [
+          2399,
+          2450,
+          15486,
+          12474,
+          2380,
+          843,
+          3816,
+          1938,
+          2852,
+          2410,
+          8511
+         ]
+        },
+        {
+         "domain": {
+          "x": [
+           0.55,
+           1
+          ],
+          "y": [
+           0.36666666666666664,
+           0.6333333333333333
+          ]
+         },
+         "hole": 0.6,
+         "hoverinfo": "label+percent",
+         "labels": [
+          "01000099",
+          "010008d3",
+          "01000c4d",
+          "01000cc2",
+          "0100128c",
+          "010038b7",
+          "01006763",
+          "01008121",
+          "01012aa8",
+          "0101cdd9",
+          "other"
+         ],
+         "textinfo": "percent",
+         "textposition": "inside",
+         "type": "pie",
+         "values": [
+          2399,
+          2450,
+          15486,
+          12474,
+          2380,
+          843,
+          3816,
+          1938,
+          2852,
+          2410,
+          8511
+         ]
+        },
+        {
+         "domain": {
+          "x": [
+           0,
+           0.45
+          ],
+          "y": [
+           0,
+           0.26666666666666666
+          ]
+         },
+         "hole": 0.6,
+         "hoverinfo": "label+percent",
+         "labels": [
+          "01000067",
+          "010000ed",
+          "01000331",
+          "010005ec",
+          "010005fa",
+          "010006cf",
+          "01000ac2",
+          "01000cc2",
+          "010014b6",
+          "01001c87",
+          "other"
+         ],
+         "marker": {
+          "colors": [
+           "rgb(82, 213, 195)",
+           "rgb(49, 73, 78)",
+           "rgb(175, 220, 215)",
+           "rgb(166, 25, 27)",
+           "rgb(178, 250, 207)",
+           "rgb(251, 45, 243)",
+           "rgb(238, 127, 34)",
+           "rgb(31, 99, 162)",
+           "rgb(77, 63, 238)",
+           "rgb(211, 14, 213)",
+           "rgb(39, 166, 111)",
+           "rgb(236, 70, 70)",
+           "rgb(119, 208, 12)",
+           "rgb(75, 231, 180)",
+           "rgb(64, 140, 126)",
+           "rgb(152, 204, 176)",
+           "rgb(94, 143, 195)",
+           "rgb(40, 204, 37)",
+           "rgb(225, 60, 89)",
+           "rgb(86, 253, 139)",
+           "rgb(149, 48, 106)",
+           "rgb(254, 213, 59)",
+           "rgb(16, 255, 154)",
+           "rgb(12, 122, 70)",
+           "rgb(110, 225, 155)",
+           "rgb(222, 185, 210)",
+           "rgb(85, 68, 142)",
+           "rgb(10, 138, 65)",
+           "rgb(247, 221, 252)",
+           "rgb(167, 126, 60)",
+           "rgb(145, 78, 145)",
+           "rgb(91, 71, 63)"
+          ]
+         },
+         "textinfo": "label",
+         "textposition": "outside",
+         "type": "pie",
+         "values": [
+          3399,
+          380,
+          245,
+          288,
+          768,
+          260,
+          246,
+          2064,
+          536,
+          500,
+          8243
+         ]
+        },
+        {
+         "domain": {
+          "x": [
+           0,
+           0.45
+          ],
+          "y": [
+           0,
+           0.26666666666666666
+          ]
+         },
+         "hole": 0.6,
+         "hoverinfo": "label+percent",
+         "labels": [
+          "01000067",
+          "010000ed",
+          "01000331",
+          "010005ec",
+          "010005fa",
+          "010006cf",
+          "01000ac2",
+          "01000cc2",
+          "010014b6",
+          "01001c87",
+          "other"
+         ],
+         "textinfo": "percent",
+         "textposition": "inside",
+         "type": "pie",
+         "values": [
+          3399,
+          380,
+          245,
+          288,
+          768,
+          260,
+          246,
+          2064,
+          536,
+          500,
+          8243
+         ]
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "font": {
+           "size": 14
+          },
+          "showarrow": false,
+          "text": "Commits",
+          "x": 0.175,
+          "y": 0.88
+         },
+         {
+          "font": {
+           "size": 14
+          },
+          "showarrow": false,
+          "text": "Issues Created",
+          "x": 0.85,
+          "y": 0.88
+         },
+         {
+          "font": {
+           "size": 14
+          },
+          "showarrow": false,
+          "text": "PRs Created",
+          "x": 0.16,
+          "y": 0.5
+         },
+         {
+          "font": {
+           "size": 14
+          },
+          "showarrow": false,
+          "text": "PRs Reviewed",
+          "x": 0.85,
+          "y": 0.5
+         },
+         {
+          "font": {
+           "size": 14
+          },
+          "showarrow": false,
+          "text": "PR Comments",
+          "x": 0.15,
+          "y": 0.12
+         }
+        ],
+        "font": {
+         "size": 11
+        },
+        "height": 950,
+        "paper_bgcolor": "#e8f4f0",
+        "showlegend": false,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Top 10 Contributors to the Ansible Repository"
+        },
+        "width": 950
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# store the top 10 in a list \n",
+    "top_10_set = [top_10_commits, top_10_issues, top_10_prs_created, top_10_prs_reviewed, top_10_pr_comments]\n",
+    "\n",
+    "# generate legend colors\n",
+    "colors=create_color_map(top_k_set=top_10_set)\n",
+    "\n",
+    "\n",
+    "specs = [[{'type':'domain'}, {'type':'domain'}], \n",
+    "         [{'type':'domain'}, {'type':'domain'}], \n",
+    "         [{'type':'domain'}, {'type':'domain'}]]\n",
+    "\n",
+    "# assign how much space in the figure each donut chart takes up\n",
+    "domains = [\n",
+    "    {'x': [0.0, 0.5], 'y': [0.0, 0.33]},\n",
+    "    {'x': [0.5, 1.0], 'y': [0.0, 0.33]},\n",
+    "    {'x': [0.0, 0.5], 'y': [0.33, 0.66]},\n",
+    "    {'x': [0.5, 1.0], 'y': [0.33, 0.66]},\n",
+    "    {'x': [0.0, 0.5], 'y': [0.66, 1.0]}\n",
+    "]\n",
+    "\n",
+    "fig = make_subplots(rows=3, cols=2, specs=specs, start_cell=\"top-left\")\n",
+    "for i, df in enumerate(top_10_set):\n",
+    "    row, col = (i // 2) + 1, (i % 2) + 1\n",
+    "\n",
+    "    common_props=dict(labels=list(df.iloc[:, 0]),values=list(df.iloc[:, 1]))\n",
+    "    \n",
+    "    fig.add_trace(go.Pie(\n",
+    "        **common_props,\n",
+    "        # name = subtitles[i],\n",
+    "        domain = domains[i],\n",
+    "        marker_colors=colors, \n",
+    "        textinfo=\"label\",\n",
+    "        textposition=\"outside\",\n",
+    "        hole=.6), row=row, col=col)\n",
+    "    \n",
+    "    # display percent inside each wedge\n",
+    "    fig.add_trace(go.Pie(\n",
+    "        **common_props, \n",
+    "        textinfo='percent',\n",
+    "        textposition='inside',\n",
+    "        hole=0.6), row=row, col=col)\n",
+    "    \n",
+    "fig.update_traces(hoverinfo='label+percent')\n",
+    "\n",
+    "fig.update_layout(height=950, width=950,\n",
+    "                  title_text=f'Top 10 Contributors to the {repo_name} Repository',\n",
+    "                  paper_bgcolor='#e8f4f0',\n",
+    "                  annotations=[dict(text='Commits', x=0.175, y=0.88, font_size=14, showarrow=False),\n",
+    "                  dict(text='Issues Created', x=0.85, y=0.88, font_size=14, showarrow=False),\n",
+    "                  dict(text='PRs Created', x=0.16, y=0.50, font_size=14, showarrow=False), \n",
+    "                  dict(text='PRs Reviewed', x=0.85, y=0.50, font_size=14, showarrow=False),\n",
+    "                  dict(text='PR Comments', x=0.15, y=0.12, font_size=14, showarrow=False)],\n",
+    "                  showlegend=False,\n",
+    "                  font_size=11)\n",
+    "\n",
+    "fig = go.Figure(fig)\n",
+    "\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can observe a trend in active contibutors among all the different perspectives we analaysed. For example, the contributor with id 01000cc2 is in the top 3 of the most active contibutors in 3 out of 5 of them. We can make the same observation for the contributor with id 01000c4d. \n",
+    "\n",
+    "Additionally, there are some activities in which the number of contributions is more evenly distributed compared to others such as creating issues vs reviewing PRs. This aligns with our logic since any user can create an issue on a repository whereas only the maintainer can review PRs."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ml23",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Quantifies the amount of contributors a project can afford to lose before it stalls by hypothetically having these people get run over a bus. Here contributors include, but are not limited to: 1) individuals who've made commits, 2) created issues, and 3) creating, reviewing, and engaging in conversation around PRs.

We further parameterized the general notion of bus factor by allowing the user to set a custom threshold for the percent of contributors a project can afford to lose, to count outliers, and to analyze how it evolves over the lifetime of the project in sliding time windows and step sizes.

All analyses in this notebook are done using Ansible as an example but are replicable with any other GitHub repository.