### PR TITLE
attribute license to "the rappel contributors"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Red Hat, LLC
+Copyright The Rappel Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This uses a better attribution line than "Red Hat, LLC" for the recent license change.

I think saying "Rappel Contributors" is a better, more accurate statement of who owns the copyright in this repo since ownership needs to be evaluated on a per-contributor basis anyway and this language is more community friendly

I hope the approvals in https://github.com/oss-aspen/Rappel/issues/264 (which were solicited only from people who made contributions to the items being moved over to the CHAOSS repos) would also cover this small change.